### PR TITLE
Swap caching strategy (hashmap vs fnv hashmap)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,14 @@
 [[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "order_book"
 version = "0.1.0"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[metadata]
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["petr-tik <petr-tik@users.noreply.github.com>"]
 
 [dependencies]
-
+fnv = "1.0.6"
 
 [profile.release]
 opt-level=3


### PR DESCRIPTION
Hello,

Here's an illustration of a quick 5% perf win for issue #1 
I have added a bench (requires nightly) 
```
test tests::bench_default_ordermap ... bench:       4,449 ns/iter (+/- 926)
test tests::bench_fnv_ordermap     ... bench:       3,866 ns/iter (+/- 949)

```