### PR TITLE
Replace btreemap with vectors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -230,6 +230,24 @@ git checkout master
 
 ```
 
+7. Use a vector for bids as well instead of a BTreeMap. Same reasoning as the previous point - took more time to implement. 
+
+```bash
+ Performance counter stats for './target/release/order_book 200':
+
+       1214.573986      cpu-clock (msec)          #    0.999 CPUs utilized          
+       1214.574111      task-clock (msec)         #    0.999 CPUs utilized          
+                 2      cs                        #    0.002 K/sec                  
+        15,969,031      cache-references          #   13.148 M/sec                    (83.21%)
+         8,445,441      cache-misses              #   52.886 % of all cache refs      (83.21%)
+     1,059,887,133      branches                  #  872.641 M/sec                    (83.21%)
+         9,499,973      branch-misses             #    0.90% of all branches          (67.07%)
+     5,387,370,693      instructions              #    2.23  insn per cycle           (83.54%)
+     2,416,001,809      cycles                    #    1.989 GHz                      (83.31%)
+
+       1.215423057 seconds time elapsed
+```
+
 
 ## Perf improvements to investigate
 

--- a/Readme.md
+++ b/Readme.md
@@ -38,16 +38,22 @@ The order book allows adding new orders, reducing current ones and printing the 
 ```rust
 type Depth = i64;
 
+type BidsVec = Vec<BidAmount>;
+type AsksVec = Vec<Amount>;
+type DepthsVec = Vec<Depth>;
+
 struct OrderBook<T: IdPriceCache + Sized> {
     cache: T,
-    bids_at_price: BTreeMap<Amount, Depth>,
     bids_total_size: i64,
-    asks_at_price: BTreeMap<Amount, Depth>,
+    asks_prices: AsksVec,
+    asks_depths: DepthsVec,
+    bids_prices: BidsVec,
+    bids_depths: DepthsVec,
     asks_total_size: i64,
     target_size: i64,
     // only 1 side is affected on Reduce or Limit order
-    last_action_side: OrderSide,   // which side was touched last
-    last_action_timestamp: String, // timestamp of last touched side
+    last_action_side: OrderSide, // which side was touched last
+    last_action_timestamp: i64,  // timestamp of last touched side
 }
 ```
 

--- a/src/amount.rs
+++ b/src/amount.rs
@@ -75,7 +75,6 @@ impl<'a> From<&'a BidAmount> for Amount {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/amount.rs
+++ b/src/amount.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Display, Formatter, Result};
 use std::ops::{AddAssign, Mul, MulAssign};
 
+use bidamount::BidAmount;
+
 // run unit tests with
 // cargo test -- amount
 
@@ -57,6 +59,23 @@ impl Display for Amount {
     }
 }
 
+impl From<BidAmount> for Amount {
+    fn from(item: BidAmount) -> Self {
+        Amount {
+            as_int: item.as_int,
+        }
+    }
+}
+
+impl<'a> From<&'a BidAmount> for Amount {
+    fn from(item: &'a BidAmount) -> Self {
+        Amount {
+            as_int: item.as_int,
+        }
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,5 +128,19 @@ mod tests {
         let mut res = String::new();
         write!(&mut res, "{}", am1).unwrap();
         assert_eq!(res, input_string);
+    }
+
+    #[test]
+    fn convert_from_bidamount_to_amount() {
+        let ba = BidAmount::new();
+        let a: Amount = ba.into();
+        assert_eq!(a, Amount::new());
+    }
+
+    #[test]
+    fn convert_from_ref_bidamount_to_amount() {
+        let ba = BidAmount::new();
+        let a: &Amount = &ba.into();
+        assert_eq!(a, &Amount::new());
     }
 }

--- a/src/bidamount.rs
+++ b/src/bidamount.rs
@@ -82,7 +82,6 @@ impl Display for BidAmount {
     }
 }
 
-
 impl From<Amount> for BidAmount {
     fn from(item: Amount) -> Self {
         BidAmount {
@@ -98,7 +97,6 @@ impl<'a> From<&'a Amount> for BidAmount {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -186,13 +184,11 @@ mod tests {
         assert_eq!(v.binary_search(&BidAmount::new_from_str("44.99")), Err(3));
     }
 
-
     #[test]
     fn convert_from_amount_to_bidamount() {
         let a = Amount::new();
         let ba: BidAmount = a.into();
         assert_eq!(ba, BidAmount::new());
-
     }
 
     #[test]
@@ -201,6 +197,5 @@ mod tests {
         let ba: &BidAmount = &a.into();
         assert_eq!(ba, &BidAmount::new());
     }
-
 
 }

--- a/src/bidamount.rs
+++ b/src/bidamount.rs
@@ -1,0 +1,206 @@
+use std::cmp::Ordering;
+use std::fmt::{Display, Formatter, Result};
+use std::ops::{AddAssign, Mul, MulAssign};
+
+use amount::Amount;
+
+// run unit tests with
+// cargo test -- amount
+
+#[derive(Copy, Clone, Debug, Eq, Hash)] // allows us to use BidAmount as a HashMap key
+pub struct BidAmount {
+    pub as_int: i64,
+}
+
+impl BidAmount {
+    pub fn new() -> Self {
+        BidAmount { as_int: 0 }
+    }
+
+    pub fn new_from_str(input_string: &str) -> Self {
+        let float_from_input = input_string.parse::<f64>();
+        let float_res = match float_from_input {
+            Ok(number_to_round) => number_to_round,
+            Err(err) => panic!("Input string {} doesn't parse as f64 {}", input_string, err),
+        };
+        let float_times_hundred = float_res * 100.0;
+        let int_res = float_times_hundred.round() as i64;
+        BidAmount { as_int: int_res }
+    }
+}
+
+impl Ord for BidAmount {
+    fn cmp(&self, other: &BidAmount) -> Ordering {
+        match self.as_int.cmp(&other.as_int) {
+            Ordering::Less => Ordering::Greater,
+            Ordering::Greater => Ordering::Less,
+            Ordering::Equal => Ordering::Equal,
+        }
+    }
+}
+
+impl PartialOrd for BidAmount {
+    fn partial_cmp(&self, other: &BidAmount) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for BidAmount {
+    fn eq(&self, other: &BidAmount) -> bool {
+        self.as_int == other.as_int
+    }
+}
+
+impl AddAssign for BidAmount {
+    fn add_assign(&mut self, other_amount: Self) {
+        self.as_int += other_amount.as_int;
+    }
+}
+
+impl MulAssign<i64> for BidAmount {
+    fn mul_assign(&mut self, multiplier: i64) {
+        self.as_int *= multiplier;
+    }
+}
+
+impl Mul<i64> for BidAmount {
+    type Output = Self;
+    fn mul(self, rhs: i64) -> Self {
+        BidAmount {
+            as_int: self.as_int * rhs,
+        }
+    }
+}
+
+impl Display for BidAmount {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        let repr = self.as_int.to_string();
+        let decimal_points = 2;
+        let idx = repr.len() - decimal_points;
+        let (quot_x, rem_x) = repr.split_at(idx);
+        write!(f, "{}.{}", quot_x, rem_x)
+    }
+}
+
+
+impl From<Amount> for BidAmount {
+    fn from(item: Amount) -> Self {
+        BidAmount {
+            as_int: item.as_int,
+        }
+    }
+}
+
+impl<'a> From<&'a Amount> for BidAmount {
+    fn from(item: &'a Amount) -> Self {
+        BidAmount {
+            as_int: item.as_int,
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructor_from_str_works() {
+        let am = BidAmount::new_from_str(&"44.12");
+        assert_eq!(am.as_int, 4412);
+    }
+
+    #[test]
+    fn constructor_default_works() {
+        let am = BidAmount::new();
+        assert_eq!(am.as_int, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn bad_constructor_panics() {
+        BidAmount::new_from_str(&"asda");
+    }
+
+    #[test]
+    fn multiply_by_zero() {
+        let mut am = BidAmount::new_from_str(&"44.12");
+        am *= 0;
+        assert_eq!(am.as_int, 0);
+    }
+
+    #[test]
+    fn multiply_by_ten() {
+        let mut am = BidAmount::new_from_str(&"44.12");
+        am *= 10;
+        assert_eq!(am.as_int, 44120);
+    }
+
+    #[test]
+    fn add_two_amounts() {
+        let mut am1 = BidAmount::new_from_str(&"44.12");
+        let am2 = BidAmount::new_from_str(&"45.80");
+        am1 += am2;
+        assert_eq!(am1.as_int, 8992);
+    }
+
+    #[test]
+    fn display_works() {
+        use std::fmt::Write as FmtWrite;
+        let input_string = "44.12";
+        let am1 = BidAmount::new_from_str(&input_string);
+        let mut res = String::new();
+        write!(&mut res, "{}", am1).unwrap();
+        assert_eq!(res, input_string);
+    }
+
+    #[test]
+    fn compare_equals() {
+        let input_string = "44.12";
+        let am1 = BidAmount::new_from_str(&input_string);
+        let am2 = BidAmount::new_from_str(&input_string);
+        assert_eq!(am1, am2);
+    }
+    #[test]
+    fn compare_less() {
+        let am1 = BidAmount::new_from_str("44.12");
+        let am2 = BidAmount::new_from_str("44.10");
+        assert_eq!(am1.cmp(&am2), Ordering::Less);
+    }
+
+    #[test]
+    fn compare_greater() {
+        let am1 = BidAmount::new_from_str("44.12");
+        let am2 = BidAmount::new_from_str("44.10");
+        assert_eq!(am2.cmp(&am1), Ordering::Greater);
+    }
+
+    #[test]
+    fn bin_search_with_new_order() {
+        let v: Vec<BidAmount> = vec!["50.20", "49.00", "45.00", "41.00"]
+            .into_iter()
+            .map(|price| BidAmount::new_from_str(price))
+            .collect();
+        assert_eq!(v.binary_search(&BidAmount::new()), Err(4));
+        assert_eq!(v.binary_search(&BidAmount::new_from_str("49.00")), Ok(1));
+        assert_eq!(v.binary_search(&BidAmount::new_from_str("44.99")), Err(3));
+    }
+
+
+    #[test]
+    fn convert_from_amount_to_bidamount() {
+        let a = Amount::new();
+        let ba: BidAmount = a.into();
+        assert_eq!(ba, BidAmount::new());
+
+    }
+
+    #[test]
+    fn convert_from_ref_amount_to_bidamount() {
+        let a = Amount::new();
+        let ba: &BidAmount = &a.into();
+        assert_eq!(ba, &BidAmount::new());
+    }
+
+
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 extern crate fnv;
 
-use std::cmp::min;
+use std::cmp::{min, Ordering, PartialEq, PartialOrd};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::env;
@@ -85,6 +85,11 @@ impl IdPriceCache for IdPriceCacheFnvMap {
 }
 
 type Depth = i64;
+
+type BidsVec = Vec<Amount>;
+type AsksVec = Vec<Amount>;
+type DepthsVec = Vec<Depth>;
+
 
 struct OrderBook<T: IdPriceCache + Sized> {
     cache: T,
@@ -444,6 +449,50 @@ mod tests {
         assert_eq!(ob.summarise_target(), Some(Amount::new_from_str("8832.56")));
 
         ob.process("28800796 R d 157");
+    }
+
+    #[test]
+    fn prices_vec_with_capacity() {
+        let vec: AsksVec = AsksVec::with_capacity(10);
+        assert_eq!(vec.len(), 0);
+    }
+
+    #[test]
+    fn prices_vec_len() {
+        let vec: AsksVec = AsksVec::with_capacity(10);
+        assert_eq!(vec.len(), 0);
+    }
+
+    #[test]
+    fn prices_vec_add() {
+        let mut vec: AsksVec = AsksVec::with_capacity(10);
+        vec.push(Amount::new());
+        assert_eq!(vec.len(), 1);
+        assert_eq!(vec[0], Amount::new());
+    }
+
+    #[test]
+    fn prices_vec_search_ok() {
+        let mut prices_vec: AsksVec = AsksVec::with_capacity(10);
+        let amounts_vec = ["44.10", "44.20", "60.00", "70.00"];
+        for item in amounts_vec.iter() {
+            let am_item = Amount::new_from_str(item);
+            prices_vec.push(am_item);
+        }
+        let idx = prices_vec.binary_search(&Amount::new_from_str(&"44.20"));
+        assert_eq!(idx, Ok(1));
+    }
+
+    #[test]
+    fn prices_vec_search_err() {
+        let mut prices_vec: AsksVec = AsksVec::with_capacity(10);
+        let amounts_vec = ["44.10", "44.20", "60.00", "70.00"];
+        for item in amounts_vec.iter() {
+            let am_item = Amount::new_from_str(item);
+            prices_vec.push(am_item);
+        }
+        let idx = prices_vec.binary_search(&Amount::new_from_str(&"84.20"));
+        assert_eq!(idx, Err(4));
     }
 
 }


### PR DESCRIPTION
Currently, only replaces asks.

Need to find and implement a rust vector that is sorted in descending order, so bids_prices can be implemented